### PR TITLE
User-friendliness fixes

### DIFF
--- a/theme.html
+++ b/theme.html
@@ -33,7 +33,7 @@
 ==============================================================================
 -->
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "//www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
 <html xmlns="//www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="<$BlogLanguageDirection$>">
 
@@ -108,13 +108,11 @@
         background-color: #888;
         color: black;
         counter-reset: figure;
-        cursor: default;
         font: 600 16px Bitter, serif;
         margin: 20px 0 25px 0 !important;
         overflow: overlay;
         overflow-x: hidden;
         text-align: center;
-        user-select: none;
       }
 
       ::-webkit-scrollbar {


### PR DESCRIPTION
Being able to select text on a web page is important, and it's frustrating when a website doesn't allow it. There's no real need to deny user-selection, and this way release note information from release posts can be very quickly copied for sharing.

I've also thrown in the shorter, valid DOCTYPE tag.